### PR TITLE
Correct silence response test in bob to match README

### DIFF
--- a/bob/BobTest.m
+++ b/bob/BobTest.m
@@ -117,14 +117,14 @@
 
 - (void)testSilence {
   NSString *input = @"";
-  NSString *expected = @"Fine, be that way.";
+  NSString *expected = @"Fine. Be that way!";
   NSString *result = [[self bob] hey:input];
   XCTAssertEqualObjects(expected, result, @"");
 }
 
 - (void)testProlongedSilence {
   NSString *input = @"     ";
-  NSString *expected = @"Fine, be that way.";
+  NSString *expected = @"Fine. Be that way!";
   NSString *result = [[self bob] hey:input];
   XCTAssertEqualObjects(expected, result, @"");
 }

--- a/bob/example.m
+++ b/bob/example.m
@@ -17,7 +17,7 @@
 
 -(NSString *) hey: (NSString *) input {
     if ([input isEmpty]) {
-        return @"Fine, be that way.";
+        return @"Fine. Be that way!";
     }
     else if ([input isShouting]) {
         return @"Whoa, chill out!";


### PR DESCRIPTION
The tests for a "silent" input did not match the expected response given in the problem description.