### PR TITLE
Use XCTAssertEqualObjects when possible

### DIFF
--- a/anagram/AnagramTest.m
+++ b/anagram/AnagramTest.m
@@ -12,70 +12,70 @@
   NSArray *results = [anagram match:@[@"hello",@"world",@"zombies",@"pants"]];
   NSArray *expected = @[];
 
-  XCTAssert([results isEqualToArray:expected]);
+  XCTAssertEqualObjects(results, expected);
 }
 
 - (void)testDetectSimpleAnagram {
   Anagram *anagram = [[Anagram alloc] initWithString:@"ant"];
   NSArray *results = [anagram match:@[@"tan",@"stand",@"at"]];
   NSArray *expected = @[@"tan"];
-  XCTAssert([results isEqualToArray:expected]);
+  XCTAssertEqualObjects(results, expected);
 }
 
 - (void)testDetectMultipleAnagrams {
   Anagram *anagram = [[Anagram alloc] initWithString:@"master"];
   NSArray *results = [anagram match:@[@"stream",@"pigeon",@"maters"]];
   NSArray *expected = @[@"stream",@"maters"];
-  XCTAssert([results isEqualToArray:expected]);
+  XCTAssertEqualObjects(results, expected);
 }
 
 - (void)testDoesNotConfuseDifferentDuplicates {
   Anagram *anagram = [[Anagram alloc] initWithString:@"galea"];
   NSArray *results = [anagram match:@[@"eagle"]];
   NSArray *expected = @[];
-  XCTAssert([results isEqualToArray:expected]);
+  XCTAssertEqualObjects(results, expected);
 }
 
 - (void)testIdenticalWordIsNotAnagram {
   Anagram *anagram = [[Anagram alloc] initWithString:@"corn"];
   NSArray *results = [anagram match:@[@"corn", @"dark", @"Corn", @"rank", @"CORN", @"cron", @"park"]];
   NSArray *expected = @[@"cron"];
-  XCTAssert([results isEqualToArray:expected]);
+  XCTAssertEqualObjects(results, expected);
 }
 
 - (void)testEliminateAnagramsWithSameChecksum {
   Anagram *anagram = [[Anagram alloc] initWithString:@"mass"];
   NSArray *results = [anagram match:@[@"last"]];
   NSArray *expected = @[];
-  XCTAssert([results isEqualToArray:expected]);
+  XCTAssertEqualObjects(results, expected);
 }
 
 - (void)testEliminateAnagramSubsets {
   Anagram *anagram = [[Anagram alloc] initWithString:@"good"];
   NSArray *results = [anagram match:@[@"dog",@"goody"]];
   NSArray *expected = @[];
-  XCTAssert([results isEqualToArray:expected]);
+  XCTAssertEqualObjects(results, expected);
 }
 
 - (void)testDetectAnagram {
   Anagram *anagram = [[Anagram alloc] initWithString:@"listen"];
   NSArray *results = [anagram match:@[@"enlists",@"google",@"inlets",@"banana"]];
   NSArray *expected = @[@"inlets"];
-  XCTAssert([results isEqualToArray:expected]);
+  XCTAssertEqualObjects(results, expected);
 }
 
 - (void)testMultipleAnagrams {
   Anagram *anagram = [[Anagram alloc] initWithString:@"allergy"];
   NSArray *results = [anagram match:@[@"gallery",@"ballerina",@"regally",@"clergy",@"largely",@"leading"]];
   NSArray *expected = @[@"gallery",@"regally",@"largely"];
-  XCTAssert([results isEqualToArray:expected]);
+  XCTAssertEqualObjects(results, expected);
 }
 
 - (void)testAnagramsAreCaseInsensitive {
   Anagram *anagram = [[Anagram alloc] initWithString:@"Orchestra"];
   NSArray *results = [anagram match:@[@"cashregister",@"Carthorse",@"radishes"]];
   NSArray *expected = @[@"Carthorse"];
-  XCTAssert([results isEqualToArray:expected]);
+  XCTAssertEqualObjects(results, expected);
 }
 
 @end

--- a/bob/BobTest.m
+++ b/bob/BobTest.m
@@ -15,118 +15,118 @@
   NSString *input = @"Tom-ay-to, tom-aaaah-to.";
   NSString *expected = @"Whatever.";
   NSString *result = [[self bob] hey:input];
-  XCTAssertEqualObjects(expected, result, @"");
+  XCTAssertEqualObjects(expected, result);
 }
 
 - (void)testShouting {
   NSString *input = @"WATCH OUT!";
   NSString *expected = @"Whoa, chill out!";
   NSString *result = [[self bob] hey:input];
-  XCTAssertEqualObjects(expected, result, @"");
+  XCTAssertEqualObjects(expected, result);
 }
 
 - (void)testAskingAQuestion {
   NSString *input = @"Does this cryogenic chamber make me look fat?";
   NSString *expected = @"Sure.";
   NSString *result = [[self bob] hey:input];
-  XCTAssertEqualObjects(expected, result, @"");
+  XCTAssertEqualObjects(expected, result);
 }
 
 - (void)testTalkingForcefully {
   NSString *input = @"Let's go make out behind the gym!";
   NSString *expected = @"Whatever.";
   NSString *result = [[self bob] hey:input];
-  XCTAssertEqualObjects(expected, result, @"");
+  XCTAssertEqualObjects(expected, result);
 }
 
 - (void)testUsingAcronyms {
   NSString *input = @"It's OK if you don't want to go to the DMV.";
   NSString *expected = @"Whatever.";
   NSString *result = [[self bob] hey:input];
-  XCTAssertEqualObjects(expected, result, @"");
+  XCTAssertEqualObjects(expected, result);
 }
 
 - (void)testForcefulQuestions {
   NSString *input = @"WHAT THE HELL WERE YOU THINKING?";
   NSString *expected = @"Whoa, chill out!";
   NSString *result = [[self bob] hey:input];
-  XCTAssertEqualObjects(expected, result, @"");
+  XCTAssertEqualObjects(expected, result);
 }
 
 - (void)testShoutingNumbers {
   NSString *input = @"1, 2, 3 GO!";
   NSString *expected = @"Whoa, chill out!";
   NSString *result = [[self bob] hey:input];
-  XCTAssertEqualObjects(expected, result, @"");
+  XCTAssertEqualObjects(expected, result);
 }
 
 - (void)testOnlyNumbers {
   NSString *input = @"1, 2, 3.";
   NSString *expected = @"Whatever.";
   NSString *result = [[self bob] hey:input];
-  XCTAssertEqualObjects(expected, result, @"");
+  XCTAssertEqualObjects(expected, result);
 }
 - (void)testQuestionWithOnlyNumbers {
   NSString *input = @"4?";
   NSString *expected = @"Sure.";
   NSString *result = [[self bob] hey:input];
-  XCTAssertEqualObjects(expected, result, @"");
+  XCTAssertEqualObjects(expected, result);
 }
 
 - (void)testShoutingWithSpecialCharacters {
   NSString *input = @"ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!";
   NSString *expected = @"Whoa, chill out!";
   NSString *result = [[self bob] hey:input];
-  XCTAssertEqualObjects(expected, result, @"");
+  XCTAssertEqualObjects(expected, result);
 }
 
 - (void)testShoutingWithUmlautsCharacters {
   NSString *input = @"ÄMLÄTS!";
   NSString *expected = @"Whoa, chill out!";
   NSString *result = [[self bob] hey:input];
-  XCTAssertEqualObjects(expected, result, @"");
+  XCTAssertEqualObjects(expected, result);
 }
 
 - (void)testCalmlySpeakingAboutUmlauts {
   NSString *input = @"ÄMLäTS!";
   NSString *expected = @"Whatever.";
   NSString *result = [[self bob] hey:input];
-  XCTAssertEqualObjects(expected, result, @"");
+  XCTAssertEqualObjects(expected, result);
 }
 
 - (void)testShoutingWithNoExclamationMark {
   NSString *input = @"I HATE YOU";
   NSString *expected = @"Whoa, chill out!";
   NSString *result = [[self bob] hey:input];
-  XCTAssertEqualObjects(expected, result, @"");
+  XCTAssertEqualObjects(expected, result);
 }
 
 - (void)testStatementContainingQuestionsMark {
   NSString *input = @"Ending with a ? means a question.";
   NSString *expected = @"Whatever.";
   NSString *result = [[self bob] hey:input];
-  XCTAssertEqualObjects(expected, result, @"");
+  XCTAssertEqualObjects(expected, result);
 }
 
 - (void)testPrattlingOn {
   NSString *input = @"Wait! Hang on.  Are you going to be OK?";
   NSString *expected = @"Sure.";
   NSString *result = [[self bob] hey:input];
-  XCTAssertEqualObjects(expected, result, @"");
+  XCTAssertEqualObjects(expected, result);
 }
 
 - (void)testSilence {
   NSString *input = @"";
   NSString *expected = @"Fine. Be that way!";
   NSString *result = [[self bob] hey:input];
-  XCTAssertEqualObjects(expected, result, @"");
+  XCTAssertEqualObjects(expected, result);
 }
 
 - (void)testProlongedSilence {
   NSString *input = @"     ";
   NSString *expected = @"Fine. Be that way!";
   NSString *result = [[self bob] hey:input];
-  XCTAssertEqualObjects(expected, result, @"");
+  XCTAssertEqualObjects(expected, result);
 }
 
 @end

--- a/etl/EtlTest.m
+++ b/etl/EtlTest.m
@@ -13,7 +13,7 @@
 
   NSDictionary *results = [ETL transform:old];
 
-  XCTAssert([expected isEqualToDictionary:results]);
+  XCTAssertEqualObjects(expected, results);
 }
 
 - (void)testTransformMoreValues {
@@ -22,7 +22,7 @@
 
   NSDictionary *results = [ETL transform:old];
 
-  XCTAssert([expected isEqualToDictionary:results]);
+  XCTAssertEqualObjects(expected, results);
 }
 
 - (void)testMoreKeys {
@@ -31,7 +31,7 @@
 
   NSDictionary *results = [ETL transform:old];
 
-  XCTAssert([expected isEqualToDictionary:results]);
+  XCTAssertEqualObjects(expected, results);
 }
 
 - (void)testFullDataSet {
@@ -52,7 +52,7 @@
 
   NSDictionary *results = [ETL transform:old];
 
-  XCTAssert([expected isEqualToDictionary:results]);
+  XCTAssertEqualObjects(expected, results);
 
 }
 

--- a/grade-school/GradeSchoolTest.m
+++ b/grade-school/GradeSchoolTest.m
@@ -11,7 +11,7 @@
   GradeSchool *school = [[GradeSchool alloc] init];
   NSDictionary *expected = @{};
   NSDictionary *result = [school db];
-  XCTAssert([result isEqualToDictionary:expected]);
+  XCTAssertEqualObjects(result, expected);
 }
 
 - (void)testAddStudent {
@@ -21,7 +21,7 @@
 
   NSDictionary *expected = @{ @2 : @[ @"Aimee" ] };
 
-  XCTAssert([result isEqualToDictionary:expected]);
+  XCTAssertEqualObjects(result, expected);
 }
 
 - (void)testAddMoreStudentsInSameClass {
@@ -33,7 +33,7 @@
 
   NSDictionary *expected = @{ @2 : @[ @"James", @"Blair", @"Paul" ] };
 
-  XCTAssert([result isEqualToDictionary:expected]);
+  XCTAssertEqualObjects(result, expected);
 }
 
 
@@ -44,7 +44,7 @@
   NSDictionary *result = [school db];
 
   NSDictionary *expected = @{ @3 : @[ @"Chelsea" ], @7 : @[ @"Logan" ] };
-  XCTAssert([result isEqualToDictionary:expected]);
+  XCTAssertEqualObjects(result, expected);
 }
 
 - (void)testGetStudentsInAGrade {
@@ -55,7 +55,7 @@
   NSArray *result = [school studentsInGrade:@5];
 
   NSArray *expected = @[ @"Franklin", @"Bradley" ];
-  XCTAssert([result isEqualToArray:expected]);
+  XCTAssertEqualObjects(result, expected);
 }
 
 - (void)testGetStudentsInANonExistantGrade {
@@ -63,7 +63,7 @@
   NSArray *result = [school studentsInGrade:@1];
 
   NSArray *expected = @[];
-  XCTAssert([result isEqualToArray:expected]);
+  XCTAssertEqualObjects(result, expected);
 }
 
 - (void)testSortSchool {
@@ -78,7 +78,7 @@
                               @4 : @[ @"Christopher", @"Jennifer" ],
                               @6 : @[ @"Kareem"] };
 
-  XCTAssert([result isEqualToDictionary:expected]);
+  XCTAssertEqualObjects(result, expected);
 }
 
 @end

--- a/nucleotide-count/NucleotideCountTest.m
+++ b/nucleotide-count/NucleotideCountTest.m
@@ -18,7 +18,7 @@
   DNA *dna = [[DNA alloc] initWithStrand:@""];
   NSDictionary *results = [dna nucleotideCounts];
   NSDictionary *expected = @{ @"A": @0, @"T" : @0, @"C" : @0, @"G" : @0 };
-  XCTAssert([results isEqualToDictionary:expected]);
+  XCTAssertEqualObjects(results, expected);
 }
 
 - (void)testRepetitiveCytidineGetsCounted {
@@ -32,7 +32,7 @@
   DNA *dna = [[DNA alloc] initWithStrand:@"GGGGGGGG"];
   NSDictionary *results = [dna nucleotideCounts];
   NSDictionary *expected = @{ @"A": @0, @"T" : @0, @"C" : @0, @"G" : @8 };
-  XCTAssert([results isEqualToDictionary:expected]);
+  XCTAssertEqualObjects(results, expected);
 }
 
 - (void)testCountsByThymidine {
@@ -61,7 +61,7 @@
   [dna count:@"U"];
   NSDictionary *results = [dna nucleotideCounts];
   NSDictionary *expected = @{ @"A": @3, @"T" : @2, @"C" : @1, @"G" : @1 };
-  XCTAssert([results isEqualToDictionary:expected]);
+  XCTAssertEqualObjects(results, expected);
 }
 
 - (void)testValidatesNucleotides {
@@ -90,7 +90,7 @@
   DNA *dna = [[DNA alloc] initWithStrand:longStrand];
   NSDictionary *results = [dna nucleotideCounts];
   NSDictionary *expected = @{ @"A": @20, @"T" : @21, @"C" : @12, @"G" : @17 };
-  XCTAssert([results isEqualToDictionary:expected]);
+  XCTAssertEqualObjects(results, expected);
 }
 
 @end

--- a/phone-number/PhoneNumberTest.m
+++ b/phone-number/PhoneNumberTest.m
@@ -12,7 +12,7 @@
   NSString *expected = @"1234567890";
   PhoneNumber *number = [[PhoneNumber alloc] initWithString:startingNumber];
   NSString *result = [number number];
-  XCTAssert([result isEqualToString:expected]);
+  XCTAssertEqualObjects(result, expected);
 }
 
 - (void)testCleansNumberWithDots {
@@ -20,7 +20,7 @@
   NSString *expected = @"1234567890";
   PhoneNumber *number = [[PhoneNumber alloc] initWithString:startingNumber];
   NSString *result = [number number];
-  XCTAssert([result isEqualToString:expected]);
+  XCTAssertEqualObjects(result, expected);
 }
 
 - (void)testValidWithElevenDigitsAndFirstIsOne {
@@ -28,7 +28,7 @@
   NSString *expected = @"1234567890";
   PhoneNumber *number = [[PhoneNumber alloc] initWithString:startingNumber];
   NSString *result = [number number];
-  XCTAssert([result isEqualToString:expected]);
+  XCTAssertEqualObjects(result, expected);
 }
 
 - (void)testInvalidWhenElevenDigits {
@@ -36,7 +36,7 @@
   NSString *expected = @"0000000000";
   PhoneNumber *number = [[PhoneNumber alloc] initWithString:startingNumber];
   NSString *result = [number number];
-  XCTAssert([result isEqualToString:expected]);
+  XCTAssertEqualObjects(result, expected);
 }
 
 - (void)testInvalidWhenNineDigits {
@@ -44,7 +44,7 @@
   NSString *expected = @"0000000000";
   PhoneNumber *number = [[PhoneNumber alloc] initWithString:startingNumber];
   NSString *result = [number number];
-  XCTAssert([result isEqualToString:expected]);
+  XCTAssertEqualObjects(result, expected);
 }
 
 - (void)testAreaCode {
@@ -52,7 +52,7 @@
   NSString *expected = @"123";
   PhoneNumber *number = [[PhoneNumber alloc] initWithString:startingNumber];
   NSString *result = [number areaCode];
-  XCTAssert([result isEqualToString:expected]);
+  XCTAssertEqualObjects(result, expected);
 }
 
 - (void)testPrettyPrint {
@@ -60,7 +60,7 @@
   NSString *expected = @"(123) 456-7890";
   PhoneNumber *number = [[PhoneNumber alloc] initWithString:startingNumber];
   NSString *result = [number description];
-  XCTAssert([result isEqualToString:expected]);
+  XCTAssertEqualObjects(result, expected);
 }
 
 - (void)testPrettyPrintWithFullUSPhoneNumber {
@@ -68,7 +68,7 @@
   NSString *expected = @"(123) 456-7890";
   PhoneNumber *number = [[PhoneNumber alloc] initWithString:startingNumber];
   NSString *result = [number description];
-  XCTAssert([result isEqualToString:expected]);
+  XCTAssertEqualObjects(result, expected);
 }
 
 @end

--- a/word-count/WordCountTest.m
+++ b/word-count/WordCountTest.m
@@ -12,7 +12,7 @@
   NSDictionary *expected = @{ @"word" : @1 };
   NSDictionary *result = [words count];
 
-  XCTAssertEqualObjects([expected objectForKey:@"word"],[result objectForKey:@"word"]);
+  XCTAssertEqualObjects(expected, result);
 }
 
 - (void)testCountOneOfEeach {
@@ -20,9 +20,7 @@
   NSDictionary *expected = @{ @"one" : @1, @"of" : @1, @"each" : @1 };
   NSDictionary *result = [words count];
 
-  XCTAssertEqualObjects([expected objectForKey:@"one"],[result objectForKey:@"one"]);
-  XCTAssertEqualObjects([expected objectForKey:@"of"],[result objectForKey:@"of"]);
-  XCTAssertEqualObjects([expected objectForKey:@"each"],[result objectForKey:@"each"]);
+  XCTAssertEqualObjects(expected, result);
 }
 
 - (void)testCountMultipleOccurrences {
@@ -30,11 +28,7 @@
   NSDictionary *expected = @{ @"one" : @1, @"fish" : @4, @"two" : @1, @"red" : @1, @"blue" : @1 };
   NSDictionary *result = [words count];
 
-  XCTAssertEqualObjects([expected objectForKey:@"one"],[result objectForKey:@"one"]);
-  XCTAssertEqualObjects([expected objectForKey:@"fish"],[result objectForKey:@"fish"]);
-  XCTAssertEqualObjects([expected objectForKey:@"two"],[result objectForKey:@"two"]);
-  XCTAssertEqualObjects([expected objectForKey:@"red"],[result objectForKey:@"red"]);
-  XCTAssertEqualObjects([expected objectForKey:@"blue"],[result objectForKey:@"blue"]);
+  XCTAssertEqualObjects(expected, result);
 }
 
 - (void)testIgnorePunctation {
@@ -42,11 +36,7 @@
   NSDictionary *expected = @{ @"car" : @1, @"carpet" : @1, @"as" : @1, @"java" : @1, @"javascript" : @1 };
   NSDictionary *result = [words count];
 
-  XCTAssertEqualObjects([expected objectForKey:@"car"],[result objectForKey:@"car"]);
-  XCTAssertEqualObjects([expected objectForKey:@"carpet"],[result objectForKey:@"carpet"]);
-  XCTAssertEqualObjects([expected objectForKey:@"as"],[result objectForKey:@"as"]);
-  XCTAssertEqualObjects([expected objectForKey:@"java"],[result objectForKey:@"java"]);
-  XCTAssertEqualObjects([expected objectForKey:@"javascript"],[result objectForKey:@"javascript"]);
+  XCTAssertEqualObjects(expected, result);
 }
 
 - (void)testIncludeNumbers {
@@ -54,9 +44,7 @@
   NSDictionary *expected = @{ @"testing" : @2, @"1" : @1, @"2" : @1 };
   NSDictionary *result = [words count];
 
-  XCTAssertEqualObjects([expected objectForKey:@"testing"],[result objectForKey:@"testing"]);
-  XCTAssertEqualObjects([expected objectForKey:@"1"],[result objectForKey:@"1"]);
-  XCTAssertEqualObjects([expected objectForKey:@"2"],[result objectForKey:@"2"]);
+  XCTAssertEqualObjects(expected, result);
 }
 
 - (void)testNormalizeCase {
@@ -64,7 +52,7 @@
   NSDictionary *expected = @{ @"go" : @3 };
   NSDictionary *result = [words count];
 
-  XCTAssertEqualObjects([expected objectForKey:@"go"],[result objectForKey:@"go"]);
+  XCTAssertEqualObjects(expected, result);
 }
 
 @end


### PR DESCRIPTION
This provides better failure output for tests.  If the test assertion fails, both values will be printed to the console.