### PR TITLE
Remove obsolete problems key

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,37 +3,6 @@
   "language": "Objective-C",
   "repository": "https://github.com/exercism/xobjective-c",
   "active": true,
-  "problems": [
-    "hello-world"
-    ,"bob"
-    ,"hamming"
-    ,"word-count"
-    ,"anagram"
-    ,"nucleotide-count"
-    ,"phone-number"
-    ,"grade-school"
-    ,"robot-name"
-    ,"leap"
-    ,"etl"
-    ,"perfect-numbers"
-    ,"space-age"
-    ,"all-your-base"
-    ,"allergies"
-    ,"roman-numerals"
-    ,"sum-of-multiples"
-    ,"gigasecond"
-    ,"meetup"
-    ,"triangle"
-    ,"scrabble-score"
-    ,"difference-of-squares"
-    ,"raindrops"
-    ,"clock"
-    ,"secret-handshake"
-    ,"acronym"
-    ,"run-length-encoding"
-    ,"largest-series-product"
-    ,"pangram"
-  ],
   "exercises": [
     {
         "difficulty": 1,


### PR DESCRIPTION
The `problems` key has been obsoleted as per [this issue](https://github.com/exercism/x-api/pull/137). This has already been succesfully implemented by the [C#](https://github.com/exercism/xcsharp#130), [F#](https://github.com/exercism/xfsharp#224) and [Haskell](https://github.com/exercism/xhaskell/pull/399) tracks, so API-wise this is a safe action.

Removing the `problems` key also makes it very impossible for people to only add a new exercise in the old, obsolete `problems` key.